### PR TITLE
Prevent configure from messing up LDFLAGS

### DIFF
--- a/user/configure
+++ b/user/configure
@@ -10859,7 +10859,7 @@ _ACEOF
 fi
 
 
-LDFLAGS+=-L/usr/local/lib
+LDFLAGS="$LDFLAGS -L/usr/local/lib"
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for nfq_open in -lnetfilter_queue" >&5
 $as_echo_n "checking for nfq_open in -lnetfilter_queue... " >&6; }
 if test "${ac_cv_lib_netfilter_queue_nfq_open+set}" = set; then :

--- a/user/configure.ac
+++ b/user/configure.ac
@@ -57,7 +57,7 @@ AM_CONDITIONAL(HAVE_NI, false)
 AC_CHECK_LIB([cap], [cap_set_flag])
 AC_CHECK_LIB([crypto], [EVP_OpenInit])
 
-LDFLAGS+=-L/usr/local/lib
+LDFLAGS="$LDFLAGS -L/usr/local/lib"
 AC_CHECK_LIB([netfilter_queue], [nfq_open])
 
 AC_CHECK_LIB([nfnetlink], [nfnl_rcvbufsiz])


### PR DESCRIPTION
This commit fixes a problem with the configure script.

When trying to build tcpcrypt on my computer, I get a build failure due to this line:
LDFLAGS+=-L/usr/local/lib

Since LDFLAGS was already set, the new -L flag is added without a space in between, resulting in:
-Wl,--as-needed-L/usr/local/lib

Which makes ld fail:
/usr/bin/ld: unrecognized option '--as-needed-L/usr/local/lib'
