### PR TITLE
Remove --all-static from LDFLAGS, fixes GCC 4.6.0

### DIFF
--- a/user/util/Makefile.am
+++ b/user/util/Makefile.am
@@ -2,7 +2,6 @@ bin_PROGRAMS = tcnetstat
 tcnetstat_SOURCES = tcnetstat.c
 tcnetstat_LDADD = $(top_builddir)/lib/libtcpcrypt.la $(AM_LDFLAGS)
 tcnetstat_CFLAGS  = -I$(top_srcdir)/include/
-tcnetstat_LDFLAGS = --all-static
 
 if OS_MINGW
 tcnetstat_LDADD	  += -lwsock32 -liphlpapi

--- a/user/util/Makefile.in
+++ b/user/util/Makefile.in
@@ -197,7 +197,6 @@ tcnetstat_SOURCES = tcnetstat.c
 tcnetstat_LDADD = $(top_builddir)/lib/libtcpcrypt.la $(AM_LDFLAGS) \
 	$(am__append_1)
 tcnetstat_CFLAGS = -I$(top_srcdir)/include/
-tcnetstat_LDFLAGS = --all-static
 all: all-am
 
 .SUFFIXES:


### PR DESCRIPTION
Previous versions of GCC ignored unknown -a\* options, so this probably
never had any effect to begin with.

See also: http://gcc.gnu.org/bugzilla/show_bug.cgi?id=46410
